### PR TITLE
Add PowerShell test coverage script

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ dotnet tool update --global dotnet-reportgenerator-globaltool
 
 > Running `dotnet tool update` for the global tool is often necessary on Apple Silicon computers to ensure the tools are installed correctly.
 
-You can collect code coverage and generate coverage badges by running the bash script in `coverage.sh` (on Windows, you can use the Git Bash shell that comes with git).
+You can collect code coverage and generate coverage badges by running the bash script `coverage.sh` (on Windows, you can use the Git Bash shell that comes with git).
 
 ```sh
 # Must give coverage script permission to run the first time it is used.

--- a/README.md
+++ b/README.md
@@ -78,18 +78,23 @@ dotnet tool update --global dotnet-reportgenerator-globaltool
 
 > Running `dotnet tool update` for the global tool is often necessary on Apple Silicon computers to ensure the tools are installed correctly.
 
-You can collect code coverage and generate coverage badges by running the bash script in `test/coverage.sh` (on Windows, you can use the Git Bash shell that comes with git).
+You can collect code coverage and generate coverage badges by running the bash script in `coverage.sh` (on Windows, you can use the Git Bash shell that comes with git).
 
 ```sh
 # Must give coverage script permission to run the first time it is used.
-chmod +x test/.coverage.sh
+chmod +x ./coverage.sh
 
 # Run code coverage:
-cd test
 ./coverage.sh
 ```
 
 You can also run test coverage through VSCode by opening the command palette and selecting `Tasks: Run Task` and then choosing `coverage`.
+
+If you are having trouble with `coverlet` finding your .NET runtime on Windows, you can use the PowerShell Script `coverage.ps1` instead.
+
+```ps
+.\coverage.ps1
+```
 
 ## ⏯ Running the Project
 

--- a/coverage.ps1
+++ b/coverage.ps1
@@ -1,0 +1,53 @@
+# To collect code coverage, you will need the following environment setup:
+#
+# - A "GODOT4" environment variable pointing to the Godot executable
+# - ReportGenerator installed
+#
+#     dotnet tool install -g dotnet-reportgenerator-globaltool
+#
+# - A version of coverlet > 3.2.0.
+#
+#   As of Jan 2023, this is not yet released.
+#
+#   The included `nuget.config` file will allow you to install a nightly
+#   version of coverlet from the coverlet nightly nuget feed.
+#
+#     dotnet tool install --global coverlet.console --prerelease.
+#
+#   You can build coverlet yourself, but you will need to edit the path to
+#   coverlet below to point to your local build of the coverlet dll.
+dotnet build --no-restore
+
+coverlet `
+  "./.godot/mono/temp/bin/Debug" --verbosity detailed `
+  --target $env:GODOT4 `
+  --targetargs "--run-tests --coverage --quit-on-finish" `
+  --format "opencover" `
+  --output "./coverage/coverage.xml" `
+  --exclude-by-file "**/test/**/*.cs" `
+  --exclude-by-file "**/*Microsoft.NET.Test.Sdk.Program.cs" `
+  --exclude-by-file "**/Godot.SourceGenerators/**/*.cs" `
+  --exclude-assemblies-without-sources "missingall"
+
+# Projects included via <ProjectReference> will be collected in code coverage.
+# If you want to exclude them, replace the string below with the names of
+# the assemblies to ignore. e.g.,
+# $ASSEMBLIES_TO_REMOVE="-AssemblyToRemove1;-AssemblyToRemove2"
+$ASSEMBLIES_TO_REMOVE=""
+
+reportgenerator `
+  -reports:"./coverage/coverage.xml" `
+  -targetdir:"./coverage/report" `
+  "-assemblyfilters:$ASSEMBLIES_TO_REMOVE" `
+  "-classfilters:-GodotPlugins.Game.Main;-Chickensoft.GodotGame.Main" `
+  -reporttypes:"Html;Badges"
+
+# Copy badges into their own folder. The badges folder should be included in
+# source control so that the README.md in the root can reference the badges.
+If (!(Test-Path -Path "./badges")) {
+    New-Item -ItemType directory -Path "./badges"
+}
+Move-Item "./coverage/report/badge_branchcoverage.svg" "./badges/branch_coverage.svg" -Force
+Move-Item "./coverage/report/badge_linecoverage.svg" "./badges/line_coverage.svg" -Force
+
+Invoke-Expression ("cmd /c start coverage/report/index.htm")


### PR DESCRIPTION
This PR adds the PowerShell script `coverage.ps1` for Windows users, and updates the README accordingly.
It also fixes the README stating that `coverage.sh` is in the test folder, since it is in the root directory of the project.