### PR TITLE
Fix test definitions not being confined to debug build

### DIFF
--- a/src/Main.cs
+++ b/src/Main.cs
@@ -15,7 +15,9 @@ using Chickensoft.GoDotTest;
 // Game.cs instead.
 
 public partial class Main : Node2D {
+#if DEBUG
   public TestEnvironment Environment = default!;
+#endif
 
   public override void _Ready() {
 //-:cnd:noEmit
@@ -34,6 +36,8 @@ public partial class Main : Node2D {
     GetTree().ChangeSceneToFile("res://src/Game.tscn");
   }
 
+#if DEBUG
   private void RunTests()
     => _ = GoTest.RunTests(Assembly.GetExecutingAssembly(), this, Environment);
+#endif
 }


### PR DESCRIPTION
Test functions rely on imports that are only added in a debug build. This fixes those statements only being included in debug builds.

<sub>I'm participating in hacktoberfest, if this looks good please add a `hacktoberfest-accepted` label so it counts towards my contribution total.<sub>