### PR TITLE
fix: compilation being removed

### DIFF
--- a/src/Main.cs
+++ b/src/Main.cs
@@ -15,12 +15,14 @@ using Chickensoft.GoDotTest;
 // Game.cs instead.
 
 public partial class Main : Node2D {
+  //-:cnd:noEmit
 #if DEBUG
   public TestEnvironment Environment = default!;
 #endif
+  //+:cnd:noEmit
 
   public override void _Ready() {
-//-:cnd:noEmit
+    //-:cnd:noEmit
 #if DEBUG
     // If this is a debug build, use GoDotTest to examine the
     // command line arguments and determine if we should run tests.
@@ -30,14 +32,16 @@ public partial class Main : Node2D {
       return;
     }
 #endif
-//+:cnd:noEmit
+    //+:cnd:noEmit
 
     // If we don't need to run tests, we can just switch to the game scene.
     GetTree().ChangeSceneToFile("res://src/Game.tscn");
   }
 
+  //-:cnd:noEmit
 #if DEBUG
   private void RunTests()
     => _ = GoTest.RunTests(Assembly.GetExecutingAssembly(), this, Environment);
 #endif
+  //+:cnd:noEmit
 }


### PR DESCRIPTION
Each `#if` needs to be surrounded by these comments to prevent the dotnet new template from removing them at generation.