### PR TITLE
fix: minor error message

### DIFF
--- a/src/Main.cs
+++ b/src/Main.cs
@@ -35,7 +35,7 @@ public partial class Main : Node2D {
     //+:cnd:noEmit
 
     // If we don't need to run tests, we can just switch to the game scene.
-    GetTree().ChangeSceneToFile("res://src/Game.tscn");
+    CallDeferred("RunScene");
   }
 
   //-:cnd:noEmit
@@ -44,4 +44,7 @@ public partial class Main : Node2D {
     => _ = GoTest.RunTests(Assembly.GetExecutingAssembly(), this, Environment);
 #endif
   //+:cnd:noEmit
+
+  private void RunScene()
+    => GetTree().ChangeSceneToFile("res://src/Game.tscn");
 }


### PR DESCRIPTION
`Parent node is busy adding/removing children, `remove_child()` can't be called at this time. Consider using `remove_child.call_deferred(child)` instead.` is fixed by following the instructions.