### PR TITLE
Fixed deprecated --install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This template allows you to easily create a C# game for Godot 4. Microsoft's `do
 
 ```sh
 # Install this template
-dotnet new --install Chickensoft.GodotGame
+dotnet new install Chickensoft.GodotGame
 
 # Generate a new project based on this template
 dotnet new chickengame --name "MyGameName" --param:author "My Name"


### PR DESCRIPTION
**Running:**
PS C:\Users\USER> dotnet new --install Chickensoft.GodotGame

**Produces the following warning:**
_Warning: use of 'dotnet new --install' is deprecated. Use 'dotnet new install' instead._
For more information, run:
   dotnet new install -h
The following template packages will be installed:
   Chickensoft.GodotGame

**This PR updates the README.md with the new syntax.**