### PR TITLE
Fixes: Debug export does not work on Android

### DIFF
--- a/Chickensoft.GodotGame.csproj
+++ b/Chickensoft.GodotGame.csproj
@@ -26,7 +26,7 @@
       $(DefaultItemExcludes);test/**/*
     </DefaultItemExcludes>
   </PropertyGroup>
-  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+  <ItemGroup Condition=" '$(Configuration)' == 'Debug' or '$(Configuration)' == 'ExportDebug' ">
     <!-- Test dependencies go here! -->
     <!-- Dependencies added here will not be included in release builds. -->
     <PackageReference Include="Chickensoft.GoDotTest" Version="1.5.2" />


### PR DESCRIPTION
As recommended by @definitelyokay in https://github.com/chickensoft-games/GodotGame/issues/47#issuecomment-2113650256 this change made Android build to work. Tested with a debug and production build as well.

Fixes: https://github.com/chickensoft-games/GodotGame/issues/47