### PR TITLE
test: use Chickensoft version of GodotTestDriver

### DIFF
--- a/Chickensoft.GodotGame.csproj
+++ b/Chickensoft.GodotGame.csproj
@@ -31,7 +31,7 @@
     <!-- Dependencies added here will not be included in release builds. -->
     <PackageReference Include="Chickensoft.GoDotTest" Version="1.5.4-godot4.3.0-beta.1" />
     <!-- Used to drive test scenes when testing visual code -->
-    <PackageReference Include="GodotTestDriver" Version="2.1.0" />
+    <PackageReference Include="Chickensoft.GodotTestDriver" Version="3.0.0" />
     <!-- Bring your own assertion library for tests! -->
     <!-- We're using Shouldly for this example, but you can use anything. -->
     <PackageReference Include="Shouldly" Version="4.2.1" />

--- a/test/src/GameTest.cs
+++ b/test/src/GameTest.cs
@@ -3,8 +3,8 @@ namespace Chickensoft.GodotGame;
 using System.Threading.Tasks;
 using Godot;
 using Chickensoft.GoDotTest;
-using GodotTestDriver;
-using GodotTestDriver.Drivers;
+using Chickensoft.GodotTestDriver;
+using Chickensoft.GodotTestDriver.Drivers;
 using Shouldly;
 
 public class GameTest : TestClass {
@@ -23,9 +23,9 @@ public class GameTest : TestClass {
   public void Cleanup() => _fixture.Cleanup();
 
   [Test]
-  public async Task TestButtonUpdatesCounter() {
+  public void TestButtonUpdatesCounter() {
     var buttonDriver = new ButtonDriver(() => _game.TestButton);
-    await buttonDriver.ClickCenter();
+    buttonDriver.ClickCenter();
     _game.ButtonPresses.ShouldBe(1);
   }
 }


### PR DESCRIPTION
While working on chickensoft-games/GodotTestDriver#4, I noticed that this template hasn't been updated to use the Chickensoft version of GodotTestDriver. This change updates the package ref and usings, and updates a method signature in the test.