### PR TITLE
fix: resolve indentation issues in the created project from this template

### DIFF
--- a/src/Main.cs
+++ b/src/Main.cs
@@ -1,13 +1,13 @@
+//-:cnd:noEmit
+
 namespace Chickensoft.GodotGame;
 
 using Godot;
 
-//-:cnd:noEmit
 #if DEBUG
 using System.Reflection;
 using Chickensoft.GoDotTest;
 #endif
-//+:cnd:noEmit
 
 // This entry-point file is responsible for determining if we should run tests.
 //
@@ -15,14 +15,11 @@ using Chickensoft.GoDotTest;
 // Game.cs instead.
 
 public partial class Main : Node2D {
-  //-:cnd:noEmit
 #if DEBUG
   public TestEnvironment Environment = default!;
 #endif
-  //+:cnd:noEmit
 
   public override void _Ready() {
-    //-:cnd:noEmit
 #if DEBUG
     // If this is a debug build, use GoDotTest to examine the
     // command line arguments and determine if we should run tests.
@@ -32,19 +29,18 @@ public partial class Main : Node2D {
       return;
     }
 #endif
-    //+:cnd:noEmit
 
     // If we don't need to run tests, we can just switch to the game scene.
     CallDeferred("RunScene");
   }
 
-  //-:cnd:noEmit
 #if DEBUG
   private void RunTests()
     => _ = GoTest.RunTests(Assembly.GetExecutingAssembly(), this, Environment);
 #endif
-  //+:cnd:noEmit
 
   private void RunScene()
     => GetTree().ChangeSceneToFile("res://src/Game.tscn");
 }
+
+//+:cnd:noEmit


### PR DESCRIPTION
This pull request resolves an indentation issue that occurs after generating a project from this template by wrapping the entire `Main.cs` file with `//-:cnd:noEmit` and `//+:cnd:noEmit`.

Resolves #79.