### PR TITLE
chore: bump Godot project version to 4.3

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Chickensoft.GodotGame"
 run/main_scene="res://src/Main.tscn"
-config/features=PackedStringArray("4.1", "C#", "Mobile")
+config/features=PackedStringArray("4.3", "C#", "Mobile")
 config/icon="res://icon.png"
 
 [dotnet]


### PR DESCRIPTION
Bumped Godot project file version to match nuget version.