### PR TITLE
chore: change C# language version to latest

### DIFF
--- a/Chickensoft.GodotGame.csproj
+++ b/Chickensoft.GodotGame.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>Chickensoft.GodotGame</RootNamespace>
     <!-- Required for some nuget packages to work -->


### PR DESCRIPTION
The Chickensoft.AutoInject NuGet package uses primary constructors, a feature introduced in C# 12. However, the template is currently configured for C# 10 based on its csproj configuration.

I propose updating the language version to `latest` which resolves the build issue with this NuGet package. For reference, the demo project is configured with `preview`.

# To reproduce

1. Create a new project from the template.
2. Add the following NuGet packages to the csproj file, as seen in the GameDemo repository's csproj file:

```xml
    <PackageReference Include="System.IO.Abstractions" Version="21.0.29" />
    <PackageReference Include="EnvironmentAbstractions" Version="4.0.0" />
    <PackageReference Include="GodotSharp.SourceGenerators" Version="2.1.1" PrivateAssets="all" OutputItemType="analyzer" />
    <PackageReference Include="Chickensoft.SaveFileBuilder" Version="1.1.0" />
    <PackageReference Include="Chickensoft.AutoInject" Version="2.3.0" PrivateAssets="all" />
    <PackageReference Include="Chickensoft.Collections" Version="1.8.3" />
    <PackageReference Include="Chickensoft.GodotNodeInterfaces" Version="2.2.4" />
    <PackageReference Include="Chickensoft.Introspection" Version="1.4.0" />
    <PackageReference Include="Chickensoft.Introspection.Generator" Version="1.4.0" PrivateAssets="all" OutputItemType="analyzer" />
    <PackageReference Include="Chickensoft.Serialization" Version="1.3.0" />
    <PackageReference Include="Chickensoft.Serialization.Godot" Version="0.3.1" />
    <PackageReference Include="Chickensoft.LogicBlocks" Version="5.3.0" />
    <PackageReference Include="Chickensoft.LogicBlocks.DiagramGenerator" Version="5.3.0" PrivateAssets="all" OutputItemType="analyzer" />
```

3. Run `dotnet build`

Expect it to build successfully, but instead, you encounter the following errors:

* ~\\.nuget\packages\chickensoft.autoinject\2.3.0\contentFiles\cs\any\Chickensoft.AutoInjectsrc\auto_connect\src\auto_connect\NodeAttribute.cs(18,27): error CS8936: Feature 'primary constructors' is not available in C# 10.0. Please use language version 12.0 or greater.
* ~\\.nuget\packages\chickensoft.autoinject\2.3.0\contentFiles\cs\any\Chickensoft.AutoInjectsrc\auto_inject\dependent\src\auto_inject\dependent\PendingProvider.cs(13,29): error CS8936: Feature 'primary constructors' is not available in C# 10.0. Please use language version 12.0 or greater.

Open for feedback.