### PR TITLE
Add snippet definitions for Godot and Chickensoft

### DIFF
--- a/.vscode/chickensoft.code-snippets
+++ b/.vscode/chickensoft.code-snippets
@@ -1,0 +1,115 @@
+{
+  // Place your workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
+  // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope
+  // is left empty or omitted, the snippet gets applied to all languages. The prefix is what is
+  // used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
+  // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders.
+  // Placeholders with the same ids are connected.
+  // Example:
+  // "Print to console": {
+  //   "scope": "javascript,typescript",
+  //   "prefix": "log",
+  //   "body": [
+  //     "console.log('$1');",
+  //     "$2"
+  //   ],
+  //   "description": "Log output to console"
+  // }
+  "Chickensoft AutoNode": {
+    "scope": "csharp",
+    "isFileTemplate": true,
+    "prefix": [ "autonode" ],
+    "body": [
+      "namespace ${1:$WORKSPACE_NAME};",
+      "",
+      "using Chickensoft.AutoInject;",
+      "using Chickensoft.Introspection;",
+      "using Godot;",
+      "",
+      "[Meta(typeof(IAutoNode))]",
+      "public partial class ${2:$TM_FILENAME_BASE} : ${3:Node} {",
+      "  public override void _Notification(int what) => this.Notify(what);",
+      "$0",
+      "}",
+      ""
+    ],
+    "description": "Chickensoft AutoNode template"
+  },
+  "Chickensoft AutoInject Provision": {
+    "scope": "csharp",
+    "prefix": [ "provide" ],
+    "body": [
+      "${1:ProvisionType} IProvide<${1:ProvisionType}>.Value() => ${2:ProvisionValue};"
+    ],
+    "description": "Chickensoft AutoInject IProvide implementation"
+  },
+  "Chickensoft AutoInject Dependency": {
+    "scope": "csharp",
+    "prefix": [ "depend" ],
+    "body": [
+      "[Dependency] ${1:public} ${2:DependencyType} ${3:DependencyValue} => this.DependOn<${2:DependencyType}>();"
+    ],
+    "description": "Chickensoft AutoInject Dependency attribute"
+  },
+  "Chickensoft AutoProp": {
+    "scope": "csharp",
+    "prefix": [ "autoprop" ],
+    "body": [
+      "public IAutoProp<${1:PropType}> ${2:PublicPropName} => ${3:_privatePropName};",
+      "private readonly AutoProp<${1:PropType}> ${3:_privatePropName} = new($0);"
+    ],
+    "description": "Chickensoft Collections AutoProp attribute"
+  },
+  "Chickensoft LogicBlock": {
+    "scope": "csharp",
+    "isFileTemplate": true,
+    "prefix": [ "logicblock", "lb" ],
+    "body": [
+      "namespace ${1:$WORKSPACE_NAME};",
+      "",
+      "using Chickensoft.Introspection;",
+      "using Chickensoft.LogicBlocks;",
+      "",
+      "[Meta, LogicBlock(typeof(State), Diagram = true)]",
+      "public partial class ${2:$TM_FILENAME_BASE} : LogicBlock<${2:$TM_FILENAME_BASE}.State> {",
+      "  public override Transition GetInitialState() => To<${3:State}>();",
+      "$0",
+      "  public abstract partial record State : StateLogic<State>;",
+      "}",
+      ""
+    ],
+    "description": "Chickensoft LogicBlock template"
+  },
+  "Chickensoft LogicBlock Inputs": {
+    "scope": "csharp",
+    "isFileTemplate": true,
+    "prefix": [ "logicblock-input", "lbin" ],
+    "body": [
+      "namespace ${1:$WORKSPACE_NAME};",
+      "",
+      "public partial class ${2:${TM_FILENAME_BASE/([a-zA-Z0-9_]*)([\\.]Input)/$1/}} {",
+      "  public static class Input {",
+      "    public readonly record struct ${3:MyInput};",
+      "  }",
+      "}",
+      ""
+    ],
+    "description": "Chickensoft LogicBlock Input class"
+  },
+  "Chickensoft LogicBlock Outputs": {
+    "scope": "csharp",
+    "isFileTemplate": true,
+    "prefix": [ "logicblock-output", "lbout" ],
+    "body": [
+      "namespace ${1:$WORKSPACE_NAME};",
+      "",
+      "public partial class ${2:${TM_FILENAME_BASE/([a-zA-Z0-9_]*)([\\.]Output)/$1/}} {",
+      "  public static class Output {",
+      "    public readonly record struct ${3:MyOutput};",
+      "  }",
+      "}",
+      ""
+    ],
+    "description": "Chickensoft LogicBlock Output class"
+  }
+}

--- a/.vscode/godot.code-snippets
+++ b/.vscode/godot.code-snippets
@@ -1,0 +1,34 @@
+{
+  // Place your workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
+  // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope
+  // is left empty or omitted, the snippet gets applied to all languages. The prefix is what is
+  // used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
+  // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders.
+  // Placeholders with the same ids are connected.
+  // Example:
+  // "Print to console": {
+  //   "scope": "javascript,typescript",
+  //   "prefix": "log",
+  //   "body": [
+  //     "console.log('$1');",
+  //     "$2"
+  //   ],
+  //   "description": "Log output to console"
+  // }
+  "Godot [Export]": {
+    "scope": "csharp",
+    "prefix": [ "export" ],
+    "body": [
+      "[Export] ${1:public} ${2:Node} ${3:MyExport} { get; set; } = default!;"
+    ],
+    "description": "Godot [Export] attribute"
+  },
+  "Godot [Signal]": {
+    "scope": "csharp",
+    "prefix": [ "signal" ],
+    "body": [
+      "[Signal] public delegate void ${1:My}EventHandler($2);"
+    ],
+    "description": "Godot [Signal] attribute"
+  }
+}


### PR DESCRIPTION
Adding VSCode snippets to project settings. One file for general Godot snippets, and another containing snippets specific to Chickensoft.

This is only intended as a first pass / POC, intended for further expansion (lifecycle methods, etc) and adjustments based on feedback.