### PR TITLE
feat: treat CS9057 as error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -142,7 +142,6 @@
   "omnisharp.enableMsBuildLoadProjectsOnDemand": false,
   "omnisharp.enableRoslynAnalyzers": true,
   "omnisharp.maxFindSymbolsItems": 3000,
-  "omnisharp.organizeImportsOnFormat": true,
   "omnisharp.useModernNet": true,
   // Remove these if you're happy with your terminal profiles.
   "terminal.integrated.defaultProfile.windows": "Git Bash",
@@ -162,5 +161,6 @@
       "icon": "terminal-powershell",
       "source": "PowerShell"
     }
-  }
+  },
+  "dotnet.formatting.organizeImportsOnFormat": true
 }

--- a/Chickensoft.GodotGame.csproj
+++ b/Chickensoft.GodotGame.csproj
@@ -5,6 +5,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>Chickensoft.GodotGame</RootNamespace>
+    <!-- Catch compiler-mismatch issues with the Introspection generator as early as possible -->
+    <WarningsAsErrors>CS9057</WarningsAsErrors>
     <!-- Required for some nuget packages to work -->
     <!-- godotengine/godot/issues/42271#issuecomment-751423827 -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>


### PR DESCRIPTION
CS9057 is a compiler warning issued when the game project is using an earlier version of the .NET compiler than was used to compile the Introspection generator. Such a mismatch can have serious, hard-to-diagnose downstream consequences for users. (See chickensoft-games/Introspection#20 and chickensoft-games/GameDemo#104.) This change treats CS9057 as an error, to make those issues easier to diagnose and fix.

Additionally, this change updates a VSCode setting to reflect new naming.