### PR TITLE
fix: don't require tests to build just to run the game

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,10 +6,21 @@
     // the following to your .zshrc, .bashrc, or .bash_profile file:
     // export GODOT="/Applications/Godot.app/Contents/MacOS/Godot"
     {
+      "name": "🕹 Debug Game",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build-without-tests",
+      "program": "${env:GODOT}",
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+    },
+    {
       "name": "🕹 Debug Game (VSCodium)",
       "type": "coreclr",
       "request": "launch",
-      "preLaunchTask": "build",
+      "preLaunchTask": "build-without-tests",
       "program": "",
       "internalConsoleOptions": "openOnSessionStart",
       "pipeTransport": {
@@ -47,24 +58,13 @@
         }
       },
     },
-    {
-      "name": "🕹 Debug Game",
-      "type": "coreclr",
-      "request": "launch",
-      "preLaunchTask": "build",
-      "program": "${env:GODOT}",
-      "args": [],
-      "cwd": "${workspaceFolder}",
-      "stopAtEntry": false,
-      "console": "integratedTerminal"
-    },
     // Debug the scene that matches the name of the currently open *.cs file
     // (if there's a scene with the same name in the same directory).
     {
       "name": "🎭 Debug Current Scene",
       "type": "coreclr",
       "request": "launch",
-      "preLaunchTask": "build",
+      "preLaunchTask": "build-without-tests",
       "program": "${env:GODOT}",
       "args": [
         "${fileDirname}/${fileBasenameNoExtension}.tscn"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,6 +19,28 @@
       }
     },
     {
+      "label": "build-without-tests",
+      "command": "dotnet",
+      "type": "process",
+      "options": {
+        "env": {
+          "SKIP_TESTS": "1"
+        }
+      },
+      "args": [
+        "build",
+      ],
+      "problemMatcher": "$msCompile",
+      "presentation": {
+        "echo": true,
+        "reveal": "silent",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": false
+      }
+    },
+    {
       "label": "coverage",
       "group": "test",
       "command": "${workspaceFolder}/coverage.sh",

--- a/Chickensoft.GodotGame.csproj
+++ b/Chickensoft.GodotGame.csproj
@@ -23,12 +23,19 @@
     <Copyright>© 2024 Chickensoft Organization</Copyright>
     <Authors>Chickensoft Organization</Authors>
     <Company>Chickensoft Organization</Company>
-    <!-- Don't include unit tests in release builds. -->
-    <DefaultItemExcludes Condition="'$(Configuration)' == 'ExportRelease'">
-      $(DefaultItemExcludes);test/**/*
-    </DefaultItemExcludes>
+
+    <SkipTests Condition="'$(SKIP_TESTS)' != ''">true</SkipTests>
+    <RunTests>false</RunTests>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(Configuration)' == 'Debug' or '$(Configuration)' == 'ExportDebug' ">
+
+  <PropertyGroup Condition="
+        ('$(Configuration)' == 'Debug' or '$(Configuration)' == 'ExportDebug')
+        and '$(SkipTests)' != 'true' ">
+    <RunTests>true</RunTests>
+    <DefineConstants>$(DefineConstants);RUN_TESTS</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(RunTests)' == 'true'">
     <!-- Test dependencies go here! -->
     <!-- Dependencies added here will not be included in release builds. -->
     <PackageReference Include="Chickensoft.GoDotTest" Version="1.6.4" />
@@ -42,8 +49,15 @@
     <!-- LightMoq is a Chickensoft package which makes it more like Moq. -->
     <PackageReference Include="LightMoq" Version="0.1.0" />
   </ItemGroup>
+
   <ItemGroup>
     <!-- Production dependencies go here! -->
     <PackageReference Include="Chickensoft.GameTools" Version="2.0.6" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(RunTests)' != 'true'">
+    <Compile          Remove="test/**/*.cs" />
+    <None             Remove="test/**/*"    />
+    <EmbeddedResource Remove="test/**/*"    />
   </ItemGroup>
 </Project>

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -4,7 +4,7 @@ namespace Chickensoft.GodotGame;
 using Godot;
 using Chickensoft.GameTools.Displays;
 
-#if DEBUG
+#if RUN_TESTS
 using System.Reflection;
 using Chickensoft.GoDotTest;
 #endif
@@ -16,7 +16,7 @@ using Chickensoft.GoDotTest;
 
 public partial class Main : Node2D {
   public Vector2I DesignResolution => Display.UHD4k;
-#if DEBUG
+#if RUN_TESTS
   public TestEnvironment Environment = default!;
 #endif
 
@@ -24,7 +24,7 @@ public partial class Main : Node2D {
     // Correct any erroneous scaling and guess sensible defaults.
     GetWindow().LookGood(WindowScaleBehavior.UIFixed, DesignResolution);
 
-#if DEBUG
+#if RUN_TESTS
     // If this is a debug build, use GoDotTest to examine the
     // command line arguments and determine if we should run tests.
     Environment = TestEnvironment.From(OS.GetCmdlineArgs());
@@ -38,7 +38,7 @@ public partial class Main : Node2D {
     CallDeferred("RunScene");
   }
 
-#if DEBUG
+#if RUN_TESTS
   private void RunTests()
     => _ = GoTest.RunTests(Assembly.GetExecutingAssembly(), this, Environment);
 #endif

--- a/test/src/GameTest.cs
+++ b/test/src/GameTest.cs
@@ -1,10 +1,10 @@
 namespace Chickensoft.GodotGame;
 
 using System.Threading.Tasks;
-using Godot;
 using Chickensoft.GoDotTest;
 using Chickensoft.GodotTestDriver;
 using Chickensoft.GodotTestDriver.Drivers;
+using Godot;
 using Shouldly;
 
 public class GameTest : TestClass {


### PR DESCRIPTION
When developing a game, it's common to want to make changes and run the game regardless of whether or not tests pass. This removes the requirement for tests to build along with the game. Since tests are included along with the Godot C# project so that they can have test fixtures (test scenes, engine assets), they were previously included by default like every other source file in the project. This fixes that.