### PR TITLE
chore: remove obj files from lfs tracking

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,7 +25,6 @@
 *.blend1 filter=lfs diff=lfs merge=lfs -text
 *.glb filter=lfs diff=lfs merge=lfs -text
 *.dae filter=lfs diff=lfs merge=lfs -text
-*.obj filter=lfs diff=lfs merge=lfs -text
 *.fbx filter=lfs diff=lfs merge=lfs -text
 
 # Build


### PR DESCRIPTION
Removed .obj files from LFS tracking, as it's a text-based format.