### PR TITLE
fix: tell Godot to use PascalCase for scene files

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -27,6 +27,10 @@ window/size/initial_position_type=3
 window/size/window_width_override=1280
 window/size/window_height_override=720
 
+[editor]
+
+naming/scene_name_casing=1
+
 [gui]
 
 theme/default_theme_scale=2.0


### PR DESCRIPTION
PascalCase is the naming convention for C# scripts and Godot includes a setting to match by using PascalCase for scene names. This convention is commonly used in C# Godot, including in the GameDemo. This change updates project.godot to use the PascalCase scene-name setting in GodotGame projects.