### PR TITLE
fix: don't clear nuget sources in nuget.config

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear />
     <add key="coverlet" value="https://pkgs.dev.azure.com/tonerdo/coverlet/_packaging/coverlet-nightly/nuget/v3/index.json" />
-    <!-- Default nuget feed -->
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Changed nuget.config so it doesn't clear the nuget sources before adding the coverlet source. Previously, any custom sources the user set up would be unavailable in their game project.

Since we're no longer clearing the nuget sources, this also takes out the nuget.config line that added the default source back in.