### PR TITLE
fix: update list of recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,15 +1,29 @@
 {
   "recommendations": [
     "alfish.godot-files",
+    "bierner.emojisense",
     "christian-kohler.path-intellisense",
+    "codezombiech.gitignore",
     "DavidAnson.vscode-markdownlint",
     "EditorConfig.EditorConfig",
+    "edwinhuish.better-comments-next",
+    "fernandoescolar.vscode-solution-explorer",
+    "qcz.text-power-tools",
+    "geequlim.godot-tools",
     "gurumukhi.selected-lines-count",
-    "jjkim.gdscript",
+    "IBM.output-colorizer",
+    "jebbs.plantuml",
     "josefpihrt-vscode.roslynator",
     "ms-dotnettools.csharp",
+    "ms-dotnettools.vscode-dotnet-runtime",
+    "muhammad-sammy.csharp",
+    "oderwat.indent-rainbow",
+    "pflannery.vscode-versionlens",
+    "qcz.text-power-tools",
     "selcukermaya.se-csproj-extensions",
+    "stkb.rewrap",
     "streetsidesoftware.code-spell-checker",
-    "VisualStudioExptTeam.vscodeintellicode"
+    "tintoy.msbuild-project-tools",
+    "yzhang.markdown-all-in-one",
   ]
 }


### PR DESCRIPTION
Fixes #144. Since there hasn't been much additional discussion on that issue, I've gone ahead and incorporated *most* of the community suggestions and removed IntelliCode.

The one recommendation I haven't (yet) included is trunk.io, because it's only free for teams < 5 or OSS work. I'm open to the argument that we could include it as a recommendation regardless and let users sort it out, but my sense was that I'd be taken off guard to have that in an OSS project, and maybe be unaware of the licensing scheme (especially since VS Code pops up that convenient "install all recommended extensions" toast). Thoughts?