### PR TITLE
chore: use "build" group in VSCode tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,6 +3,7 @@
   "tasks": [
     {
       "label": "build",
+      "group": "build",
       "command": "dotnet",
       "type": "process",
       "args": [
@@ -20,6 +21,7 @@
     },
     {
       "label": "build-without-tests",
+      "group": "build",
       "command": "dotnet",
       "type": "process",
       "options": {


### PR DESCRIPTION
Added "build" and "build-without-tests" tasks in VSCode config to the "build" group. Users can now access both from the "Run Build Task" command, allowing them to check for build errors in the without-tests build without having to initiate a debug session.

<img width="903" height="128" alt="Screenshot 2025-10-06 162415" src="https://github.com/user-attachments/assets/e756bfc2-efb8-4b54-bb0e-4f6ef2079a02" />
