### PR TITLE
chore: order csproj ItemGroups for inclusion

### DIFF
--- a/Chickensoft.GodotGame.csproj
+++ b/Chickensoft.GodotGame.csproj
@@ -35,6 +35,11 @@
     <DefineConstants>$(DefineConstants);RUN_TESTS</DefineConstants>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Production dependencies go here! -->
+    <PackageReference Include="Chickensoft.GameTools" Version="2.1.18" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(RunTests)' == 'true'">
     <!-- Test dependencies go here! -->
     <!-- Dependencies added here will not be included in release builds. -->
@@ -48,11 +53,6 @@
     <PackageReference Include="LightMock.Generator" Version="1.2.3" />
     <!-- LightMoq is a Chickensoft package which makes it more like Moq. -->
     <PackageReference Include="LightMoq" Version="0.1.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Production dependencies go here! -->
-    <PackageReference Include="Chickensoft.GameTools" Version="2.1.18" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RunTests)' != 'true'">


### PR DESCRIPTION
Placed the production-dependencies `ItemGroup` above the test-dependencies `ItemGroup` in the game csproj. Now when users execute `dotnet add package`, the new package will by default be added to the production-dependencies group. This avoids placing production dependencies in a group that is compiled out in non-test builds, which causes unforeseen build errors when building without tests.