### PR TITLE
quality: update to new editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 # --------------------------------------------------------------------------- #
 #                 Chickensoft C# Style — .editorconfig                        #
 # --------------------------------------------------------------------------- #
-#  Godot-friendly, K&R coding style with a bit of Dart-style flair thrown in. #
+#  Godot-friendly coding style with a bit of Dart-style flair thrown in.      #
 # --------------------------------------------------------------------------- #
 #                                                                             #
 #                                                                             #
@@ -46,6 +46,7 @@ indent_style = space
 indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
+end_of_line = lf
 
 ##########################################
 # File Extension Settings
@@ -85,6 +86,10 @@ indent_size = 2
 
 # Batch Files
 [*.{cmd,bat}]
+end_of_line = crlf
+
+# Powershell Files
+[*.ps1]
 end_of_line = crlf
 
 # Bash Files
@@ -156,6 +161,10 @@ dotnet_style_coalesce_expression = true:warning
 dotnet_style_null_propagation = true:warning
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 
+# Unused parameters and methods
+dotnet_diagnostic.IDE0060.severity = warn
+dotnet_diagnostic.IDE0051.severity = warn
+
 # File header preferences
 # Keep operators at end of line when wrapping.
 dotnet_style_operator_placement_when_wrapping = end_of_line
@@ -173,7 +182,7 @@ csharp_style_var_for_built_in_types = true:warning
 csharp_style_var_when_type_is_apparent = true:warning
 csharp_style_var_elsewhere = true:warning
 # Expression-bodied members
-csharp_style_expression_bodied_methods = true:warning
+csharp_style_expression_bodied_methods = when_on_single_line:warning
 csharp_style_expression_bodied_constructors = false:warning
 csharp_style_expression_bodied_operators = true:warning
 csharp_style_expression_bodied_properties = true:warning
@@ -200,45 +209,13 @@ csharp_style_throw_expression = true:warning
 csharp_style_conditional_delegate_call = true:warning
 # 'using' directive preferences
 csharp_using_directive_placement = inside_namespace:warning
-# Modifier preferences
-# Don't suggest making public methods static. Very annoying.
-csharp_prefer_static_local_function = false
-# Only suggest making private methods static (if they don't use instance data).
-dotnet_code_quality.CA1822.api_surface = private
-
-##########################################
-# Unnecessary Code Rules
-##########################################
-
-# .NET Unnecessary code rules
-
-dotnet_code_quality_unused_parameters = non_public:suggestion
-dotnet_remove_unnecessary_suppression_exclusions = none
-dotnet_diagnostic.IDE0079.severity = warning
-
-# C# Unnecessary code rules
-
-# Chickensoft Unused Code Additions
-#
-# Unfortunately for VSCode users, disabling these rules prevents you from
-# detecting unused code. Enabling them will trigger the roslyn analyzers'
-# automatic code fixes to remove unused code, which is very annoying when
-# you're actively coding or using reflection.
-#
-# I have not found a way to disable automatic fixes while keeping
-# warnings/suggestions/etc in the editor. If you find a way, please file an
-# issue or open a PR.
-
-# Don't remove method parameters that are unused.
-dotnet_diagnostic.IDE0060.severity = none
-dotnet_diagnostic.RCS1163.severity = none
-
-# Don't remove methods that are unused.
-dotnet_diagnostic.IDE0051.severity = none
-dotnet_diagnostic.RCS1213.severity = none
-
 # Use discard variable for unused expression values.
 csharp_style_unused_value_expression_statement_preference = discard_variable
+csharp_style_unused_value_assignment_preference = discard_variable
+
+##########################################
+# Formatting Rules
+##########################################
 
 # .NET formatting rules
 
@@ -257,7 +234,7 @@ dotnet_diagnostic.IDE0130.severity = none
 # C# formatting rules
 
 # Newline options
-csharp_new_line_before_open_brace = none
+csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
@@ -303,6 +280,15 @@ csharp_preserve_single_line_blocks = true
 
 # Namespace options
 csharp_style_namespace_declarations = file_scoped:warning
+
+##########################################
+# Unnecessary Code Rules
+##########################################
+
+# .NET Unnecessary code rules
+
+dotnet_code_quality_unused_parameters = non_public:suggestion
+dotnet_remove_unnecessary_suppression_exclusions = none
 
 ##########################################
 # .NET Naming Rules
@@ -408,52 +394,25 @@ dotnet_naming_symbols.unspecified.applicable_accessibilities = *
 # Chickensoft Rule Overrides
 ##########################################
 
-# Don't require culture info for ToString()
-dotnet_diagnostic.CA1304.severity = none
-# Don't require a string comparison for comparing strings.
-dotnet_diagnostic.CA1310.severity = none
-# Don't require a string format specifier.
-dotnet_diagnostic.CA1305.severity = none
 # Allow protected fields.
 dotnet_diagnostic.CA1051.severity = none
 # Don't warn about checking values that are supposedly never null. Sometimes
 # they are actually null.
 dotnet_diagnostic.CS8073.severity = none
-# Don't remove seemingly "unnecessary" assignments, as they often have
-# intended side-effects.
-dotnet_diagnostic.IDE0059.severity = none
-# Switch/case should always have a default clause. Tell that to Roslynator.
-dotnet_diagnostic.RCS1070.severity = none
-# Tell roslynator not to eat unused parameters.
-dotnet_diagnostic.RCS1163.severity = suggestion
-# Tell dotnet not to remove unused parameters.
-dotnet_diagnostic.IDE0060.severity = suggestion
-# Tell roslynator not to remove `partial` modifiers.
-dotnet_diagnostic.RCS1043.severity = none
-# Tell roslynator not to make classes static so aggressively.
-dotnet_diagnostic.RCS1102.severity = none
-# Roslynator wants to make properties readonly all the time, so stop it.
-# The developer knows best when it comes to contract definitions with Godot.
-dotnet_diagnostic.RCS1170.severity = none
 # Allow expression values to go unused, even without discard variable.
 # Otherwise, using Moq would be way too verbose.
 dotnet_diagnostic.IDE0058.severity = none
-# Enums don't need to declare explicit values. Everyone knows they start at 0.
-dotnet_diagnostic.RCS1161.severity = none
-# Allow unconstrained type parameter to be checked for null.
-dotnet_diagnostic.RCS1165.severity = none
-# Allow keyword-based names so that parameter names like `@event` can be used.
-dotnet_diagnostic.CA1716.severity = none
-# Let me put comments where I like
-dotnet_diagnostic.RCS1181.severity = none
 # Allow me to use the word Collection if I want.
 dotnet_diagnostic.CA1711.severity = none
+# Don't warn about using reserved keywords (e.g., methods named "On")
+dotnet_diagnostic.CA1716.severity = none
+# Don't warn about public methods that can be marked static
+# (tests frequently don't access member data, and GoDotTest won't call static methods)
+dotnet_code_quality.CA1822.api_surface = private
 # No primary constructors — not supported well by tooling.
 dotnet_diagnostic.IDE0290.severity = none
 # Let me write dumb if statements for readability.
 dotnet_diagnostic.IDE0046.severity = none
-# Don't make me use expression bodies for methods
-dotnet_diagnostic.IDE0022.severity = none
 # DO make me populate a *switch expression*
 dotnet_diagnostic.IDE0072.severity = warning
 # Don't make me populate a *switch statement*

--- a/src/Game.cs
+++ b/src/Game.cs
@@ -2,7 +2,8 @@ namespace Chickensoft.GodotGame;
 
 using Godot;
 
-public partial class Game : Control {
+public partial class Game : Control
+{
   public Button TestButton { get; private set; } = default!;
   public int ButtonPresses { get; private set; }
 

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -14,13 +14,15 @@ using Chickensoft.GoDotTest;
 // If you want to edit your game's main entry-point, please see Game.tscn and
 // Game.cs instead.
 
-public partial class Main : Node2D {
+public partial class Main : Node2D
+{
   public Vector2I DesignResolution => Display.UHD4k;
 #if RUN_TESTS
   public TestEnvironment Environment = default!;
 #endif
 
-  public override void _Ready() {
+  public override void _Ready()
+  {
     // Correct any erroneous scaling and guess sensible defaults.
     GetWindow().LookGood(WindowScaleBehavior.UIFixed, DesignResolution);
 
@@ -28,7 +30,8 @@ public partial class Main : Node2D {
     // If this is a debug build, use GoDotTest to examine the
     // command line arguments and determine if we should run tests.
     Environment = TestEnvironment.From(OS.GetCmdlineArgs());
-    if (Environment.ShouldRunTests) {
+    if (Environment.ShouldRunTests)
+    {
       CallDeferred("RunTests");
       return;
     }

--- a/test/src/GameTest.cs
+++ b/test/src/GameTest.cs
@@ -7,14 +7,16 @@ using Chickensoft.GodotTestDriver.Drivers;
 using Godot;
 using Shouldly;
 
-public class GameTest : TestClass {
+public class GameTest : TestClass
+{
   private Game _game = default!;
   private Fixture _fixture = default!;
 
   public GameTest(Node testScene) : base(testScene) { }
 
   [SetupAll]
-  public async Task Setup() {
+  public async Task Setup()
+  {
     _fixture = new Fixture(TestScene.GetTree());
     _game = await _fixture.LoadAndAddScene<Game>();
   }
@@ -23,7 +25,8 @@ public class GameTest : TestClass {
   public void Cleanup() => _fixture.Cleanup();
 
   [Test]
-  public void TestButtonUpdatesCounter() {
+  public void TestButtonUpdatesCounter()
+  {
     var buttonDriver = new ButtonDriver(() => _game.TestButton);
     buttonDriver.ClickCenter();
     _game.ButtonPresses.ShouldBe(1);


### PR DESCRIPTION
Used the new editorconfig to update the project's code style. (See chickensoft-games/EditorConfig#5.)

* Removes Roslynator rules (since we no longer use Roslynator).
* Uses LF as the newline for all files, except Windows-specific files like bat, cmd, and ps1.
* Explicitly sets rule to suggest expression-body style only for single-line methods.
* Warns about unused parameters and methods, since newer tooling is less aggressive about auto-removing them.
* Warns about string methods not using modern locale-aware techniques.
* Removes duplicative rules.
* The big one: Puts opening braces on a new line.