### PR TITLE
ci: enable xrandr in test workflow

### DIFF
--- a/.github/workflows/visual_tests.yaml
+++ b/.github/workflows/visual_tests.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: 💾 Install Graphics Driver Emulators
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: mesa-vulkan-drivers binutils
+          packages: mesa-vulkan-drivers binutils x11-xserver-utils
           version: 1.0
 
       - name: 🤖 Setup Godot


### PR DESCRIPTION
Added x11-xserver-utils to the list of apt packages to install in the test workflow, so that xrandr can be used by Platform. (Fixes test failure in #187.)