### PR TITLE
ci: remove --coverage flag from test invocation

### DIFF
--- a/.github/workflows/visual_tests.yaml
+++ b/.github/workflows/visual_tests.yaml
@@ -71,13 +71,17 @@ jobs:
 
       - name: 🌋 Run Tests in Godot
         run: |
-          xvfb-run godot --audio-driver Dummy --rendering-driver ${{ matrix.render-driver }} --run-tests --quit-on-finish --coverage
+          xvfb-run godot --audio-driver Dummy --rendering-driver ${{ matrix.render-driver }} --run-tests --quit-on-finish
 
           # The --coverage flag is used by GoDotTest to control the exit code
           # of Godot by force-exiting through C#.
           #
-          # Since Godot tends to exit with non-zero exit codes (even on success)
-          # this flag allows GoDotTest to ensure that this step will only fail
-          # when the tests fail.
+          # Since Godot sometimes exits with non-zero exit codes (even on success),
+          # adding this flag to the above command may allow GoDotTest to ensure that
+          # this step will only fail when the tests fail, and not because Godot didn't
+          # exit cleanly.
+          #
+          # However, note that the --coverage flag can sometimes cause other failures
+          # by forcing Godot to exit before it can clean up its resources completely.
 
           echo "Finished running tests in Godot with emulated ${{ matrix.render-driver }} graphics."


### PR DESCRIPTION
Fixes #193. May also resolve test errors in workflow, e.g., [this run for a renovate PR](https://github.com/chickensoft-games/GodotGame/actions/runs/20085971807/job/57623410724?pr=192).

Removed the --coverage flag from the invocation of Godot in the test workflow, to avoid errors from GoDotTest forcing Godot to exit before it has successfully cleaned up resources (and possibly threads).