### PR TITLE
fix: use long line for test-build condition

### DIFF
--- a/Chickensoft.GodotGame.csproj
+++ b/Chickensoft.GodotGame.csproj
@@ -28,7 +28,7 @@
     <RunTests>false</RunTests>
   </PropertyGroup>
 
-  <PropertyGroup Condition="&#xA;        ('$(Configuration)' == 'Debug' or '$(Configuration)' == 'ExportDebug')&#xA;        and '$(SkipTests)' != 'true' ">
+  <PropertyGroup Condition="('$(Configuration)' == 'Debug' or '$(Configuration)' == 'ExportDebug') and '$(SkipTests)' != 'true' ">
     <RunTests>true</RunTests>
     <DefineConstants>$(DefineConstants);RUN_TESTS</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
VSCode on Windows will modify strings in XML that contain line breaks to instead contain special characters. These characters cause failures during template instantiation with `dotnet new`. Using a long line without breaks for the string containing test-build conditions fixes the issue.